### PR TITLE
Ship LICENSE along with source distribution to PYPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include README.rst
+include LICENSE
+include CHANGELOG.rst


### PR DESCRIPTION
Downloads from pypi don't include the LICENSE file.  :P  Whoops!
