### PR TITLE
add origin, location, protocol and accept headers to HyBi-07 preamble

### DIFF
--- a/txws.py
+++ b/txws.py
@@ -380,14 +380,13 @@ class WebSocketProtocol(ProtocolWrapper):
 
         self.sendCommonPreamble()
 
+        if self.codec:
+            self.transport.write("Sec-WebSocket-Protocol: %s\r\n" % self.codec)
+
         challenge = self.headers["Sec-WebSocket-Key"]
         response = make_accept(challenge)
 
-        self.transport.writeSequence([
-            "Sec-WebSocket-Protocol: %s\r\n" % self.codec,
-            "Sec-WebSocket-Accept: %s\r\n" % response,
-            "\r\n",
-        ])
+        self.transport.write("Sec-WebSocket-Accept: %s\r\n\r\n" % response)
 
     def parseFrames(self):
         """


### PR DESCRIPTION
When connecting to a txWS via chome, I get the following error:

Error during WebSocket handshake: Sec-WebSocket-Protocol mismatch

This appears to be because the Sec-WebSocket-Protocol header is not sent in the server response. This pull request fixes that, plus adds origin, location and accept headers.
