### PR TITLE
Handle multiple comma-separated WS protocols (codecs).

### DIFF
--- a/txws.py
+++ b/txws.py
@@ -460,18 +460,28 @@ class WebSocketProtocol(ProtocolWrapper):
             self.origin = self.headers["Origin"]
 
         # Check whether a codec is needed. WS calls this a "protocol" for
-        # reasons I cannot fathom.
-        protocol = None
+        # reasons I cannot fathom. Newer versions of noVNC (0.4+) sets
+        # multiple comma-separated codecs, handle this by chosing first one
+        # we can encode/decode.
+        protocols = None
         if "WebSocket-Protocol" in self.headers:
-            protocol = self.headers["WebSocket-Protocol"]
+            protocols = self.headers["WebSocket-Protocol"]
         elif "Sec-WebSocket-Protocol" in self.headers:
-            protocol = self.headers["Sec-WebSocket-Protocol"]
+            protocols = self.headers["Sec-WebSocket-Protocol"]
 
-        if protocol:
-            if protocol not in encoders or protocol not in decoders:
+        if isinstance(protocols, basestring):
+            protocols = [p.strip() for p in protocols.split(',')]
+
+            for protocol in protocols:
+                if protocol in encoders or protocol in decoders:
+                    log.msg("Using WS protocol %s!" % protocol)
+                    self.codec = protocol
+                    break
+
                 log.msg("Couldn't handle WS protocol %s!" % protocol)
+
+            if not self.codec:
                 return False
-            self.codec = protocol
 
         # Start the next phase of the handshake for HyBi-00.
         if is_hybi00(self.headers):


### PR DESCRIPTION
Master branch of noVNC project sets WebSocket-Protocol/Sec-WebSocket-Protocol header with multiple comma-separated codecs (binary, base64). Current form will trow error: 

```
Couldn't handle WS protocol binary, base64!
```

This patch will enable iteration through header codecs and will set `self.codec` variable to first codec we can encode/decode.

Patch solves "reported bug" using noVNC master branch with Ganeti Web Manager (https://groups.google.com/forum/#!topic/ganeti-webmgr/84umQtMCXP8)
