### PR TITLE
Include tests in release source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include CHANGELOG.rst
 include LICENSE
 include README.rst
 include version.txt
+include tests.py


### PR DESCRIPTION
I feel like the test suite should be included in the release tarball that is uploaded to pypi. Linux distributions, such as Debian, base their packages of Python modules on the pypi release. It is very useful to be able to run the test suite when building a Debian package. Running the test suite can catch mistakes in the packaging or errors introduced into dependencies.

I've written a more detailed description of my thinking on the Debian Python mailing list: https://lists.debian.org/debian-python/2016/04/msg00074.html