### PR TITLE
Allow binary as a 'protocol'

### DIFF
--- a/txws.py
+++ b/txws.py
@@ -95,12 +95,17 @@ opcode_types = {
     0xa: PONG,
 }
 
+def straight_through(data):
+    return data
+
 encoders = {
     "base64": b64encode,
+    "binary": straight_through,
 }
 
 decoders = {
     "base64": b64decode,
+    "binary": straight_through,
 }
 
 # Fake HTTP stuff, and a couple convenience methods for examining fake HTTP
@@ -555,6 +560,8 @@ class WebSocketProtocol(ProtocolWrapper):
 
             if not self.codec:
                 return False
+            elif self.codec == 'binary':
+                self.setBinaryMode(True)
 
         # Start the next phase of the handshake for HyBi-00.
         if is_hybi00(self.headers):


### PR DESCRIPTION
noVNC has removed support for base64 encoding in the latest release: https://github.com/novnc/noVNC/commit/38781d931ec18304f51ed3469faff8387e3cbc55

This means that noVNC ends up sending the header "Sec-WebSocket-Protocol:binary", and vncAuthProxy/txWS can't deal with that because binary is not in the encoders/decoders dicts and txWS returns false from validateHeaders.

Tested against xen/qemu VNCN server -> vncauthproxy -> noVNC v0.6.2