### PR TITLE
Remove deprecated usage of array.tostring()

### DIFF
--- a/txws.py
+++ b/txws.py
@@ -228,7 +228,7 @@ def mask(buf, key):
     buf = array.array("B", buf)
     for i in range(len(buf)):
         buf[i] ^= key[i % 4]
-    return buf.tostring()
+    return buf.tobytes()
 
 def make_hybi07_frame(buf, opcode=0x1):
     """


### PR DESCRIPTION
array.tostring() is a deprecated alias to array.tobytes()

It was removed in Python 3.9.