### PR TITLE
Python 3.9 no longer has array.array.tostring

### DIFF
--- a/txws.py
+++ b/txws.py
@@ -228,7 +228,7 @@ def mask(buf, key):
     buf = array.array("B", buf)
     for i in range(len(buf)):
         buf[i] ^= key[i % 4]
-    return buf.tostring()
+    return buf.tobytes()
 
 def make_hybi07_frame(buf, opcode=0x1):
     """


### PR DESCRIPTION
Fix Python3.9 no longer having array.array.tostring as it is now array.array.tobytes